### PR TITLE
Update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/check-badges.yml
+++ b/.github/workflows/check-badges.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check badges in README.md
         run: ./scripts/check-badges.bash "README.md"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,9 +23,9 @@ jobs:
         node-version: [18.x, 20.x, 22.x, lts/*, latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/try-publish.yml
+++ b/.github/workflows/try-publish.yml
@@ -14,9 +14,9 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use the latest versiob of Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           # Switch node-version: latest (23) to 22 for a while
           # https://github.com/nodejs/node/issues/55410


### PR DESCRIPTION
## Summary
- GitHub is deprecating Node 20 on Actions runners (EOL April 2026, removal Fall 2026)
- Updated all actions to their latest major versions with Node 24 runtime support
- actions/checkout v4 → v6
- actions/setup-node v4 → v6

## Test plan
- [ ] CI workflows pass on this PR branch